### PR TITLE
Setting the fuse_conn_info.enable.case_sensitive flag will result in the...

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1158,6 +1158,8 @@ static void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		outarg.flags |= FUSE_VOL_RENAME;
 	if (f->conn.enable.xtimes)
 		outarg.flags |= FUSE_XTIMES;
+    if (f->conn.enable.case_insensitive)
+        outarg.flags |= FUSE_CASE_INSENSITIVE;
 #endif /* __APPLE__ */
 
 	if (f->debug) {


### PR DESCRIPTION
... file system being reported as case insensitive.
