### PR TITLE
Makes non-error debug message less confusing.

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -220,7 +220,7 @@ static int send_reply_iov(fuse_req_t req, int error, struct iovec *iov,
 		fprintf(stderr,
 			"   unique: %llu, error: %i (%s), outsize: %i\n",
 			(unsigned long long) out.unique, out.error,
-			strerror(-out.error), out.len);
+			out.error ? strerror(-out.error) : "OK", out.len);
 	res = fuse_chan_send(req->ch, iov, count);
 	free_req(req);
 


### PR DESCRIPTION
In the POSIX API, errno is only valid when an error actually occurs,
and zero is not a valid error code.  Hence, strerror() maps 0
to "Unknown error".  However, the FUSE messaging API has an always
present "error" field which is zero in the no-error case.  The
debugging messages shouldn't report this as "Unknown error".

I'm not sure why the code is using "out.error" instead of the local variable "error", but I left that aspect alone.  For the master branch, it will need to use "out->error".
