### PR TITLE
Partially revert 5473133e

### DIFF
--- a/lib/mount_darwin.c
+++ b/lib/mount_darwin.c
@@ -300,7 +300,7 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 		return;
 	}
 
-	DADiskUnmount(disk, kDADiskUnmountOptionDefault, NULL, NULL);
+	DADiskUnmount(disk, kDADiskUnmountOptionForce, NULL, NULL);
 }
 
 void

--- a/lib/mount_darwin.c
+++ b/lib/mount_darwin.c
@@ -270,12 +270,15 @@ fuse_mount_opt_proc(void *data, const char *arg, int key,
 void
 fuse_kern_unmount(DADiskRef disk, int fd)
 {
+    fprintf(stderr, "fuse_kern_unmount\n");
+
 	struct stat sbuf;
 	char dev[128];
 	char *ep, *rp = NULL, *umount_cmd;
 
 	if (!disk) {
-		/*
+        fprintf(stderr, "fuse_kern_unmount !disk\n");
+        /*
 		 * Filesystem has already been unmounted, all we need to do is
 		 * make sure fd is closed.
 		 */
@@ -285,6 +288,7 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 	}
 
 	if (fstat(fd, &sbuf) == -1) {
+        fprintf(stderr, "fuse_kern_unmount fstat failed\n");
 		return;
 	}
 
@@ -292,15 +296,27 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 
 	if (strncmp(dev, OSXFUSE_DEVICE_BASENAME,
 		    sizeof(OSXFUSE_DEVICE_BASENAME) - 1)) {
+        fprintf(stderr, "fuse_kern_unmount strcmp failed\n");
 		return;
 	}
 
 	strtol(dev + sizeof(OSXFUSE_DEVICE_BASENAME) - 1, &ep, 10);
 	if (*ep != '\0') {
+        fprintf(stderr, "fuse_kern_unmount strtol failed\n");
 		return;
 	}
 
-	DADiskUnmount(disk, kDADiskUnmountOptionDefault, NULL, NULL);
+    fprintf(stderr, "fuse_kern_unmount DADiskUnmount %p\n", disk);
+
+    CFDictionaryRef dict = DADiskCopyDescription(disk);
+    fprintf(stderr, "fuse_kern_unmount DADiskCopyDescription -> %p\n", dict);
+    CFShow(dict);
+    CFRelease(dict);
+
+    DADiskUnmount(disk, kDADiskUnmountOptionForce, NULL, NULL);
+    fprintf(stderr, "fuse_kern_unmount done\n");
+
+    // TODO https://github.com/osxfuse/osxfuse/issues/385
 }
 
 void

--- a/lib/mount_darwin.c
+++ b/lib/mount_darwin.c
@@ -270,15 +270,12 @@ fuse_mount_opt_proc(void *data, const char *arg, int key,
 void
 fuse_kern_unmount(DADiskRef disk, int fd)
 {
-    fprintf(stderr, "fuse_kern_unmount\n");
-
 	struct stat sbuf;
 	char dev[128];
 	char *ep, *rp = NULL, *umount_cmd;
 
 	if (!disk) {
-        fprintf(stderr, "fuse_kern_unmount !disk\n");
-        /*
+		/*
 		 * Filesystem has already been unmounted, all we need to do is
 		 * make sure fd is closed.
 		 */
@@ -288,7 +285,6 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 	}
 
 	if (fstat(fd, &sbuf) == -1) {
-        fprintf(stderr, "fuse_kern_unmount fstat failed\n");
 		return;
 	}
 
@@ -296,27 +292,15 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 
 	if (strncmp(dev, OSXFUSE_DEVICE_BASENAME,
 		    sizeof(OSXFUSE_DEVICE_BASENAME) - 1)) {
-        fprintf(stderr, "fuse_kern_unmount strcmp failed\n");
 		return;
 	}
 
 	strtol(dev + sizeof(OSXFUSE_DEVICE_BASENAME) - 1, &ep, 10);
 	if (*ep != '\0') {
-        fprintf(stderr, "fuse_kern_unmount strtol failed\n");
 		return;
 	}
 
-    fprintf(stderr, "fuse_kern_unmount DADiskUnmount %p\n", disk);
-
-    CFDictionaryRef dict = DADiskCopyDescription(disk);
-    fprintf(stderr, "fuse_kern_unmount DADiskCopyDescription -> %p\n", dict);
-    CFShow(dict);
-    CFRelease(dict);
-
-    DADiskUnmount(disk, kDADiskUnmountOptionForce, NULL, NULL);
-    fprintf(stderr, "fuse_kern_unmount done\n");
-
-    // TODO https://github.com/osxfuse/osxfuse/issues/385
+	DADiskUnmount(disk, kDADiskUnmountOptionDefault, NULL, NULL);
 }
 
 void


### PR DESCRIPTION
Commit 5473133ecef92879ee57b524e0a065215f819969 introduced a number of log statement, and changed the DADiskUnmountOptions parameter passed to DADiskUnmount from kDADiskUnmountOptionDefault to kDADiskUnmountOptionForce.

This commit partially reverts 5473133ecef92879ee57b524e0a065215f819969 so that it removes the log statements (probably intended for debugging) while maintaining the parameter change to DADiskUnmount.