### PR TITLE
Move semaphore implementation on Darwin over to libdispatch.

### DIFF
--- a/lib/fuse_darwin.c
+++ b/lib/fuse_darwin.c
@@ -2,7 +2,8 @@
  * Copyright (c) 2006-2008 Amit Singh/Google Inc.
  * Copyright (c) 2012 Anatol Pomozov
  * Copyright (c) 2011-2017 Benjamin Fleischer
- */
+ * Copyright (c) 2017 Dave MacLachlan/Google Inc.
+*/
 
 #include "fuse_i.h"
 #include "fuse_darwin_private.h"
@@ -11,252 +12,55 @@
 #include <errno.h>
 #include <libgen.h>
 #include <mach-o/dyld.h>
-#include <pthread.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/param.h>
-#include <sys/types.h>
 #include <unistd.h>
 
-#include <CoreFoundation/CoreFoundation.h>
-
-/*
- * Semaphore implementation based on:
- *
- * Copyright (C) 2000,02 Free Software Foundation, Inc.
- * This file is part of the GNU C Library.
- * Written by Ga<EB>l Le Mignot <address@hidden>
- *
- * The GNU C Library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Library General Public License as
- * published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
- *
- * The GNU C Library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public
- * License along with the GNU C Library; see the file COPYING.LIB.  If not,
- * write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
- */
-
-#include <assert.h>
-
-/* Semaphores */
-
-#define __SEM_ID_NONE  0x0
-#define __SEM_ID_LOCAL 0xcafef00d
 
 /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_init.html */
 int
-fuse_sem_init(fuse_sem_t *sem, int pshared, unsigned int value)
+fuse_sem_init(dispatch_semaphore_t *sem, int pshared, unsigned int value)
 {
 	if (pshared) {
 		errno = ENOSYS;
 		return -1;
 	}
 
-	sem->id = __SEM_ID_NONE;
-
-	if (pthread_cond_init(&sem->__data.local.count_cond, NULL)) {
-		goto cond_init_fail;
-	}
-
-	if (pthread_mutex_init(&sem->__data.local.count_lock, NULL)) {
-		goto mutex_init_fail;
-	}
-
-	sem->__data.local.count = value;
-	sem->id = __SEM_ID_LOCAL;
-
+  dispatch_semaphore_t local_sem = dispatch_semaphore_create(value);
+  if (local_sem == NULL) {
+    errno = ENOSPC;
+    return -1;
+  }
+  *sem = local_sem;
 	return 0;
-
-mutex_init_fail:
-
-	pthread_cond_destroy(&sem->__data.local.count_cond);
-
-cond_init_fail:
-
-	return -1;
 }
 
 /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_destroy.html */
 int
-fuse_sem_destroy(fuse_sem_t *sem)
+fuse_sem_destroy(dispatch_semaphore_t *sem)
 {
-	int res = 0;
-
-	pthread_mutex_lock(&sem->__data.local.count_lock);
-
-	sem->id = __SEM_ID_NONE;
-	pthread_cond_broadcast(&sem->__data.local.count_cond);
-
-	if (pthread_cond_destroy(&sem->__data.local.count_cond)) {
-		res = -1;
-	}
-
-	pthread_mutex_unlock(&sem->__data.local.count_lock);
-
-	if (pthread_mutex_destroy(&sem->__data.local.count_lock)) {
-		res = -1;
-	}
-
-	return res;
-}
-
-int
-fuse_sem_getvalue(fuse_sem_t *sem, unsigned int *sval)
-{
-	int res = 0;
-
-	pthread_mutex_lock(&sem->__data.local.count_lock);
-
-	if (sem->id != __SEM_ID_LOCAL) {
-		res = -1;
-		errno = EINVAL;
-	} else {
-		*sval = sem->__data.local.count;
-	}
-
-	pthread_mutex_unlock(&sem->__data.local.count_lock);
-
-	return res;
+  dispatch_release(*sem);
+  return 0;
 }
 
 /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_post.html */
 int
-fuse_sem_post(fuse_sem_t *sem)
+fuse_sem_post(dispatch_semaphore_t *sem)
 {
-	int res = 0;
-
-	pthread_mutex_lock(&sem->__data.local.count_lock);
-
-	if (sem->id != __SEM_ID_LOCAL) {
-		res = -1;
-		errno = EINVAL;
-	} else if (sem->__data.local.count < FUSE_SEM_VALUE_MAX) {
-		sem->__data.local.count++;
-		if (sem->__data.local.count == 1) {
-			pthread_cond_signal(&sem->__data.local.count_cond);
-		}
-	} else {
-		errno = ERANGE;
-		res = -1;
-	}
-
-	pthread_mutex_unlock(&sem->__data.local.count_lock);
-
-	return res;
-}
-
-/* http://www.opengroup.org/onlinepubs/009695399/functions/sem_timedwait.html */
-int
-fuse_sem_timedwait(fuse_sem_t *sem, const struct timespec *abs_timeout)
-{
-	int res = 0;
-
-	if (abs_timeout &&
-	    (abs_timeout->tv_nsec < 0 || abs_timeout->tv_nsec >= 1000000000)) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	pthread_cleanup_push((void(*)(void*))&pthread_mutex_unlock,
-			     &sem->__data.local.count_lock);
-
-	pthread_mutex_lock(&sem->__data.local.count_lock);
-
-	if (sem->id != __SEM_ID_LOCAL) {
-		errno = EINVAL;
-		res = -1;
-	} else {
-		if (!sem->__data.local.count) {
-			res = pthread_cond_timedwait(&sem->__data.local.count_cond,
-						     &sem->__data.local.count_lock,
-						     abs_timeout);
-		}
-		if (res) {
-			assert(res == ETIMEDOUT);
-			res = -1;
-			errno = ETIMEDOUT;
-		} else if (sem->id != __SEM_ID_LOCAL) {
-			res = -1;
-			errno = EINVAL;
-		} else {
-			sem->__data.local.count--;
-		}
-	}
-
-	pthread_cleanup_pop(1);
-
-	return res;
-}
-
-/* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_trywait.html */
-int
-fuse_sem_trywait(fuse_sem_t *sem)
-{
-	int res = 0;
-
-	pthread_mutex_lock(&sem->__data.local.count_lock);
-
-	if (sem->id != __SEM_ID_LOCAL) {
-		res = -1;
-		errno = EINVAL;
-	} else if (sem->__data.local.count) {
-		sem->__data.local.count--;
-	} else {
-		res = -1;
-		errno = EAGAIN;
-	}
-
-	pthread_mutex_unlock (&sem->__data.local.count_lock);
-
-	return res;
+  dispatch_semaphore_signal(*sem);
+	return 0;
 }
 
 /* http://www.opengroup.org/onlinepubs/007908799/xsh/sem_wait.html */
 int
-fuse_sem_wait(fuse_sem_t *sem)
+fuse_sem_wait(dispatch_semaphore_t *sem)
 {
-	int res = 0;
-
-	pthread_cleanup_push((void(*)(void*))&pthread_mutex_unlock,
-			     &sem->__data.local.count_lock);
-
-	pthread_mutex_lock(&sem->__data.local.count_lock);
-
-	if (sem->id != __SEM_ID_LOCAL) {
-		errno = EINVAL;
-		res = -1;
-	} else {
-		if (!sem->__data.local.count) {
-			pthread_cond_wait(&sem->__data.local.count_cond,
-					  &sem->__data.local.count_lock);
-			if (!sem->__data.local.count) {
-				/* spurious wakeup, assume it is an interruption */
-				res = -1;
-				errno = EINTR;
-				goto out;
-			}
-		}
-		if (sem->id != __SEM_ID_LOCAL) {
-			res = -1;
-			errno = EINVAL;
-		} else {
-			sem->__data.local.count--;
-		}
-	}
-
-out:
-	pthread_cleanup_pop(1);
-
-	return res;
+  if (dispatch_semaphore_wait(*sem, DISPATCH_TIME_FOREVER) != 0) {
+    errno = EINTR;
+    return -1;
+  }
+	return 0;
 }
 
 /********************/

--- a/lib/fuse_darwin_private.h
+++ b/lib/fuse_darwin_private.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2006-2008 Amit Singh/Google Inc.
  * Copyright (c) 2011-2017 Benjamin Fleischer
+ * Copyright (c) 2017 Dave MacLachlan/Google Inc.
  */
 
 #ifdef __APPLE__
@@ -8,70 +9,31 @@
 #ifndef _FUSE_DARWIN_PRIVATE_H_
 #define _FUSE_DARWIN_PRIVATE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "fuse_darwin.h"
+#include "fuse_param.h"
 
-#include <fuse_param.h>
 #include <fuse_ioctl.h>
-#include <fuse_version.h>
 
-#include <pthread.h>
-#include <strhash.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <time.h>
+#include <dispatch/dispatch.h>
 
 #include <DiskArbitration/DiskArbitration.h>
 
-#ifdef __cplusplus
-}
+#ifdef _SYS_SEMAPHORE_H_
+#error Caller must not include <semaphore.h>
 #endif
 
 /* Semaphores */
+typedef dispatch_semaphore_t sem_t;
 
-struct __local_sem_t {
-	unsigned int    count;
-	pthread_mutex_t count_lock;
-	pthread_cond_t  count_cond;
-};
-
-typedef struct fuse_sem {
-	int id;
-	union {
-		struct __local_sem_t local;
-	} __data;
-} fuse_sem_t;
-
-#define FUSE_SEM_VALUE_MAX ((int32_t)32767)
-
-int fuse_sem_init(fuse_sem_t *sem, int pshared, unsigned int value);
-int fuse_sem_destroy(fuse_sem_t *sem);
-int fuse_sem_getvalue(fuse_sem_t *sem, unsigned int *value);
-int fuse_sem_post(fuse_sem_t *sem);
-int fuse_sem_timedwait(fuse_sem_t *sem, const struct timespec *abs_timeout);
-int fuse_sem_trywait(fuse_sem_t *sem);
-int fuse_sem_wait(fuse_sem_t *sem);
-
-#ifdef DARWIN_SEMAPHORE_COMPAT
-
-/* Caller must not include <semaphore.h> */
-
-typedef fuse_sem_t sem_t;
+int fuse_sem_init(dispatch_semaphore_t *sem, int pshared, unsigned int value);
+int fuse_sem_destroy(dispatch_semaphore_t *sem);
+int fuse_sem_post(dispatch_semaphore_t *sem);
+int fuse_sem_wait(dispatch_semaphore_t *sem);
 
 #define sem_init(s, p, v)   fuse_sem_init(s, p, v)
 #define sem_destroy(s)      fuse_sem_destroy(s)
-#define sem_getvalue(s, v)  fuse_sem_getvalue(s, v)
 #define sem_post(s)         fuse_sem_post(s)
-#define sem_timedwait(s, t) fuse_sem_timedwait(s, t)
-#define sem_trywait(s)      fuse_sem_trywait(s)
 #define sem_wait(s)         fuse_sem_wait(s)
-
-#define SEM_VALUE_MAX       FUSE_SEM_VALUE_MAX
-
-#endif /* DARWIN_SEMAPHORE_COMPAT */
 
 /* lock operations for flock(2) */
 #ifndef LOCK_SH
@@ -81,6 +43,7 @@ typedef fuse_sem_t sem_t;
 #  define LOCK_UN         0x08            /* unlock file */
 #endif /* !LOCK_SH */
 
+/* Caller is responsable for freeing return value. */
 char *fuse_resource_path(const char *path);
 
 extern DASessionRef fuse_dasession;

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -22,7 +22,6 @@
 #include <unistd.h>
 #include <signal.h>
 #ifdef __APPLE__
-#  define DARWIN_SEMAPHORE_COMPAT 1
 #  include "fuse_darwin_private.h"
 #else
 #  include <semaphore.h>

--- a/lib/mount_darwin.c
+++ b/lib/mount_darwin.c
@@ -270,12 +270,15 @@ fuse_mount_opt_proc(void *data, const char *arg, int key,
 void
 fuse_kern_unmount(DADiskRef disk, int fd)
 {
+    fprintf(stderr, "fuse_kern_unmount\n");
+
 	struct stat sbuf;
 	char dev[128];
 	char *ep, *rp = NULL, *umount_cmd;
 
 	if (!disk) {
-		/*
+        fprintf(stderr, "fuse_kern_unmount !disk\n");
+        /*
 		 * Filesystem has already been unmounted, all we need to do is
 		 * make sure fd is closed.
 		 */
@@ -285,6 +288,7 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 	}
 
 	if (fstat(fd, &sbuf) == -1) {
+        fprintf(stderr, "fuse_kern_unmount fstat failed\n");
 		return;
 	}
 
@@ -292,15 +296,27 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 
 	if (strncmp(dev, OSXFUSE_DEVICE_BASENAME,
 		    sizeof(OSXFUSE_DEVICE_BASENAME) - 1)) {
+        fprintf(stderr, "fuse_kern_unmount strcmp failed\n");
 		return;
 	}
 
 	strtol(dev + sizeof(OSXFUSE_DEVICE_BASENAME) - 1, &ep, 10);
 	if (*ep != '\0') {
+        fprintf(stderr, "fuse_kern_unmount strtol failed\n");
 		return;
 	}
 
-	DADiskUnmount(disk, kDADiskUnmountOptionDefault, NULL, NULL);
+    fprintf(stderr, "fuse_kern_unmount DADiskUnmount %p\n", disk);
+
+    CFDictionaryRef dict = DADiskCopyDescription(disk);
+    fprintf(stderr, "fuse_kern_unmount DADiskCopyDescription -> %p\n", dict);
+    CFShow(dict);
+    CFRelease(dict);
+
+    DADiskUnmount(disk, kDADiskUnmountOptionForce, NULL, NULL);
+    fprintf(stderr, "fuse_kern_unmount done\n");
+
+    // TODO https://github.com/osxfuse/osxfuse/issues/385
 }
 
 void


### PR DESCRIPTION
This cleans up fuse_darwin significantly, and moves the semaphore
calls over on top of libdispatch. libdispatch has been around since
10.6, so should be no compatibility problems.

Advantages: reduction in code size (maintenance), and small performance boost