### PR TITLE
Clean up deprecation warnings.

### DIFF
--- a/lib/modules/threadid.c
+++ b/lib/modules/threadid.c
@@ -28,12 +28,18 @@ extern int pthread_setugid_np(uid_t, gid_t);
 	int   needsettid = (issuser && calleruid);			\
 									\
 	if (needsettid) {						\
+    _Pragma("clang diagnostic push")    \
+    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")    \
 		pthread_setugid_np(calleruid, callergid);		\
+    _Pragma("clang diagnostic pop")    \
 	}
 
 #define THREADID_POST()							\
 	if (needsettid) {						\
+    _Pragma("clang diagnostic push")    \
+    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")    \
 		pthread_setugid_np(KAUTH_UID_NONE, KAUTH_GID_NONE);	\
+    _Pragma("clang diagnostic pop")    \
 	}
 
 struct threadid {

--- a/lib/mount_darwin.c
+++ b/lib/mount_darwin.c
@@ -270,12 +270,15 @@ fuse_mount_opt_proc(void *data, const char *arg, int key,
 void
 fuse_kern_unmount(DADiskRef disk, int fd)
 {
+    fprintf(stderr, "fuse_kern_unmount\n");
+
 	struct stat sbuf;
 	char dev[128];
 	char *ep, *rp = NULL, *umount_cmd;
 
 	if (!disk) {
-		/*
+        fprintf(stderr, "fuse_kern_unmount !disk\n");
+        /*
 		 * Filesystem has already been unmounted, all we need to do is
 		 * make sure fd is closed.
 		 */
@@ -285,6 +288,7 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 	}
 
 	if (fstat(fd, &sbuf) == -1) {
+        fprintf(stderr, "fuse_kern_unmount fstat failed\n");
 		return;
 	}
 
@@ -292,15 +296,27 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 
 	if (strncmp(dev, OSXFUSE_DEVICE_BASENAME,
 		    sizeof(OSXFUSE_DEVICE_BASENAME) - 1)) {
+        fprintf(stderr, "fuse_kern_unmount strcmp failed\n");
 		return;
 	}
 
 	strtol(dev + sizeof(OSXFUSE_DEVICE_BASENAME) - 1, &ep, 10);
 	if (*ep != '\0') {
+        fprintf(stderr, "fuse_kern_unmount strtol failed\n");
 		return;
 	}
 
-	DADiskUnmount(disk, kDADiskUnmountOptionDefault, NULL, NULL);
+    fprintf(stderr, "fuse_kern_unmount DADiskUnmount %p\n", disk);
+
+    CFDictionaryRef dict = DADiskCopyDescription(disk);
+    fprintf(stderr, "fuse_kern_unmount DADiskCopyDescription -> %p\n", dict);
+    CFShow(dict);
+    CFRelease(dict);
+
+    DADiskUnmount(disk, kDADiskUnmountOptionForce, NULL, NULL);
+    fprintf(stderr, "fuse_kern_unmount done\n");
+
+    // TODO https://github.com/osxfuse/osxfuse/issues/385
 }
 
 void


### PR DESCRIPTION
Turn off warnings regarding the pthread_setugid_np calls.
They are deprecated because:
"Use of per-thread security contexts is error-prone and discouraged."