### PR TITLE
Turn off readdir_ino "on" by default

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -5283,7 +5283,7 @@ struct fuse *fuse_new_common(struct fuse_chan *ch, struct fuse_args *args,
 	if (!f->conf.ac_attr_timeout_set)
 		f->conf.ac_attr_timeout = f->conf.attr_timeout;
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 	/*
 	 * In FreeBSD, we always use these settings as inode numbers
 	 * are needed to make getcwd(3) work.


### PR DESCRIPTION
readdir_ino was turned "on" by default on Apple platforms, and it does not
appear to be required. getcwd works just fine without it turned on and
there is supporting evidence from a couple of places
(https://sourceforge.net/p/fuse/mailman/message/29170050/)
that it is basically ignored.

If we find places that users do need it, they can turn it on like on any other
file system.

This gets rid of a significant lock in readdir, and improves performance of
readdir significantly.