### PR TITLE
Add Grand Central Dispatch support for dispatching requests in fuse.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,11 @@ AC_CHECK_FUNCS([posix_fallocate])
 AC_CHECK_MEMBERS([struct stat.st_atim])
 AC_CHECK_MEMBERS([struct stat.st_atimensec])
 AC_CHECK_MEMBERS([struct stat.st_atimespec])
+AC_CHECK_HEADERS([dispatch/dispatch.h], [], [],
+[#ifdef HAVE_DISPATCH_DISPATCH_H
+# include <dispatch/dispatch.h>
+#endif
+])
 
 LIBS=
 AC_SEARCH_LIBS(dlopen, [dl])

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ AC_CHECK_MEMBERS([struct stat.st_atimensec])
 AC_CHECK_MEMBERS([struct stat.st_atimespec])
 AC_CHECK_HEADERS([dispatch/dispatch.h], [], [],
 [#ifdef HAVE_DISPATCH_DISPATCH_H
-# include <dispatch/dispatch.h>
+#include <dispatch/dispatch.h>
 #endif
 ])
 

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -760,6 +760,21 @@ void fuse_exit(struct fuse *f);
 int fuse_loop_mt(struct fuse *f);
 
 /**
+ * FUSE event loop based on libdispatch
+ *
+ * Requests from the kernel are processed, and the appropriate
+ * operations are called.  Request are processed in parallel by
+ * distributing them onto an dispatch queue asynchronously.
+ *
+ * Calling this function requires libdispatch to be linked to
+ * the application.
+ *
+ * @param f the FUSE handle
+ * @return 0 if no error occurred, -1 otherwise
+ */
+int fuse_loop_dispatch(struct fuse *f);
+
+/**
  * Get the current context
  *
  * The context is only valid for the duration of a filesystem

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1774,6 +1774,14 @@ int fuse_session_loop(struct fuse_session *se);
  */
 int fuse_session_loop_mt(struct fuse_session *se);
 
+/**
+ * Enter a multi-threaded event loop based on libdispatch
+ *
+ * @param se the session
+ * @return 0 on success, -1 on error
+ */
+int fuse_session_loop_dispatch(struct fuse_session *se);
+
 /* ----------------------------------------------------------- *
  * Channel interface					       *
  * ----------------------------------------------------------- */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -44,6 +44,7 @@ libfuse_la_SOURCES = 		\
 	fuse_i.h		\
 	fuse_kern_chan.c	\
 	fuse_loop.c		\
+	fuse_loop_dispatch.c	\
 	fuse_loop_mt.c		\
 	fuse_lowlevel.c		\
 	fuse_misc.h		\

--- a/lib/fuse_loop_dispatch.c
+++ b/lib/fuse_loop_dispatch.c
@@ -1,0 +1,110 @@
+/*
+ FUSE: Filesystem in Userspace
+ Copyright (C) 2001-2007  Miklos Szeredi <miklos@szeredi.hu>
+ 
+ This program can be distributed under the terms of the GNU LGPLv2.
+ See the file COPYING.LIB.
+ */
+
+/*
+ * Copyright (c) 2006-2008 Amit Singh/Google Inc.
+ * Copyright (c) 2011-2012 Benjamin Fleischer
+ * Copyright (c) 2017 Dave MacLachlan/Google Inc.
+ */
+
+#include "config.h"
+
+#if HAVE_DISPATCH_DISPATCH_H
+
+#include "fuse_i.h"
+#include "fuse_lowlevel.h"
+
+#include <dispatch/dispatch.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <signal.h>
+
+static register_signal_source(int sig,
+                              dispatch_queue_t queue,
+                              struct fuse_session *se) {
+  signal(sig, SIG_IGN);
+  dispatch_source_t sig_src =
+  dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, sig, 0, queue);
+  dispatch_source_set_event_handler(sig_src, ^{
+#ifdef __APPLE__
+    struct fuse_chan *ch = fuse_session_next_chan(se, NULL);
+    if (ch)
+      fuse_unmount(NULL, ch);
+#else
+    fuse_session_exit(se);
+#endif
+  });
+  dispatch_resume(sig_src);
+}
+
+int fuse_session_loop_dispatch(struct fuse_session *se)
+{
+  int res = 0;
+  struct fuse_chan *ch = fuse_session_next_chan(se, NULL);
+  size_t bufsize = fuse_chan_bufsize(ch);
+  
+  dispatch_queue_t queue =
+  dispatch_queue_create("fuse_session", DISPATCH_QUEUE_CONCURRENT);
+  dispatch_group_t group = dispatch_group_create();
+  
+  // Set up signal handling.
+  int signals[] = { SIGTERM, SIGINT, SIGHUP, SIGQUIT };
+  for (size_t i = 0; i < sizeof(signals) / sizeof(signals[0]); ++i) {
+    register_signal_source(signals[i], queue, se);
+  }
+  
+  char *buf = (char *) malloc(bufsize);
+  if (!buf) {
+    fprintf(stderr, "fuse: failed to allocate read buffer\n");
+    return -1;
+  }
+  while (!fuse_session_exited(se)) {
+    
+    struct fuse_chan *tmpch = ch;
+    struct fuse_buf fbuf = {
+      .mem = buf,
+      .size = bufsize,
+    };
+    
+    res = fuse_session_receive_buf(se, &fbuf, &tmpch);
+    
+    if (res == -EINTR) {
+      continue;
+    }
+    if (res <= 0) {
+      break;
+    }
+    
+    char *newbuf = (char *)malloc(res);
+    if (!newbuf) {
+      fprintf(stderr, "fuse: failed to allocate process buffer\n");
+      res = -1;
+      break;
+    }
+    memcpy(newbuf, fbuf.mem, res);
+    fbuf.mem = newbuf;
+    fbuf.size = res;
+    dispatch_group_async(group, queue, ^{
+      fuse_session_process_buf(se, &fbuf, tmpch);
+      free(fbuf.mem);
+    });
+  }
+  dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+  dispatch_release(group);
+  dispatch_release(queue);
+  free(buf);
+  fuse_session_reset(se);
+  return res < 0 ? -1 : 0;
+}
+
+int fuse_loop_dispatch(struct fuse *f) {
+  return fuse_session_loop_dispatch(fuse_get_session(f));
+}
+
+#endif // HAVE_DISPATCH_DISPATCH_H

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -445,10 +445,15 @@ static int fuse_main_common(int argc, char *argv[],
 	if (fuse == NULL)
 		return 1;
 
-	if (multithreaded)
+	if (multithreaded) {
+#if HAVE_DISPATCH_DISPATCH_H
+		res = fuse_loop_dispatch(fuse);
+#else
 		res = fuse_loop_mt(fuse);
-	else
+#endif
+	} else {
 		res = fuse_loop(fuse);
+	}
 
 	fuse_teardown_common(fuse, mountpoint);
 	if (res == -1)

--- a/lib/mount_darwin.c
+++ b/lib/mount_darwin.c
@@ -270,12 +270,15 @@ fuse_mount_opt_proc(void *data, const char *arg, int key,
 void
 fuse_kern_unmount(DADiskRef disk, int fd)
 {
+    fprintf(stderr, "fuse_kern_unmount\n");
+
 	struct stat sbuf;
 	char dev[128];
 	char *ep, *rp = NULL, *umount_cmd;
 
 	if (!disk) {
-		/*
+        fprintf(stderr, "fuse_kern_unmount !disk\n");
+        /*
 		 * Filesystem has already been unmounted, all we need to do is
 		 * make sure fd is closed.
 		 */
@@ -285,6 +288,7 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 	}
 
 	if (fstat(fd, &sbuf) == -1) {
+        fprintf(stderr, "fuse_kern_unmount fstat failed\n");
 		return;
 	}
 
@@ -292,15 +296,27 @@ fuse_kern_unmount(DADiskRef disk, int fd)
 
 	if (strncmp(dev, OSXFUSE_DEVICE_BASENAME,
 		    sizeof(OSXFUSE_DEVICE_BASENAME) - 1)) {
+        fprintf(stderr, "fuse_kern_unmount strcmp failed\n");
 		return;
 	}
 
 	strtol(dev + sizeof(OSXFUSE_DEVICE_BASENAME) - 1, &ep, 10);
 	if (*ep != '\0') {
+        fprintf(stderr, "fuse_kern_unmount strtol failed\n");
 		return;
 	}
 
-	DADiskUnmount(disk, kDADiskUnmountOptionDefault, NULL, NULL);
+    fprintf(stderr, "fuse_kern_unmount DADiskUnmount %p\n", disk);
+
+    CFDictionaryRef dict = DADiskCopyDescription(disk);
+    fprintf(stderr, "fuse_kern_unmount DADiskCopyDescription -> %p\n", dict);
+    CFShow(dict);
+    CFRelease(dict);
+
+    DADiskUnmount(disk, kDADiskUnmountOptionForce, NULL, NULL);
+    fprintf(stderr, "fuse_kern_unmount done\n");
+
+    // TODO https://github.com/osxfuse/osxfuse/issues/385
 }
 
 void


### PR DESCRIPTION
This reduces the number of threads being created and destroyed by a huge number
making it far easier to attempt to reason about what fuse is doing.
It makes doing performance analysis much easier and cuts down on the number of
resources being used.

Tested under load on a custom file system, and made sure that signal handlers
were firing correctly.