### PR TITLE
Order locks in get_path2 to avoid deadlocks

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -1223,7 +1223,7 @@ static int try_get_path2(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
 {
 	int err;
 
-	/* FIXME: locking two paths needs deadlock checking */
+	/* locking two paths needs deadlock checking -- see get_path2_ordered */
 	err = try_get_path(f, nodeid1, name1, path1, wnode1, true);
 	if (!err) {
 		err = try_get_path(f, nodeid2, name2, path2, wnode2, true);
@@ -1237,7 +1237,7 @@ static int try_get_path2(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
 	return err;
 }
 
-static int get_path2(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
+static int get_path2_ordered(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
 		     fuse_ino_t nodeid2, const char *name2,
 		     char **path1, char **path2,
 		     struct node **wnode1, struct node **wnode2)
@@ -1268,6 +1268,20 @@ static int get_path2(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
 	pthread_mutex_unlock(&f->lock);
 
 	return err;
+}
+
+static int get_path2(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
+		     fuse_ino_t nodeid2, const char *name2,
+		     char **path1, char **path2,
+		     struct node **wnode1, struct node **wnode2)
+{
+	/* order the locks to avoid deadlock */
+	if (nodeid1 < nodeid2 || (nodeid1 == nodeid2 && strcmp(name1, name2) <= 0))
+		return get_path2_ordered(f,
+			nodeid1, name1, nodeid2, name2, path1, path2, wnode1, wnode2);
+	else
+		return get_path2_ordered(f,
+			nodeid2, name2, nodeid1, name1, path2, path1, wnode2, wnode1);
 }
 
 static void free_path_wrlock(struct fuse *f, fuse_ino_t nodeid,


### PR DESCRIPTION
This PR fixes the deadlock described in osxfuse/osxfuse#495.

Without the PR applied the command `fsstress -d fsstress -v -n 100 -p 3 -s 1524260405` fails to complete. The file system becomes unresponsive and is eventually forcibly unmounted.

With the PR applied the `fsstress` command completes without problems.