### PR TITLE
rename: perform user mode dir loop check

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -1216,6 +1216,49 @@ static int get_path_wrlock(struct fuse *f, fuse_ino_t nodeid, const char *name,
 	return get_path_common(f, nodeid, name, path, wnode);
 }
 
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#define CHECK_DIR_LOOP
+#endif
+
+#if defined(CHECK_DIR_LOOP)
+static int check_dir_loop(struct fuse *f,
+			  fuse_ino_t nodeid1, const char *name1,
+			  fuse_ino_t nodeid2, const char *name2)
+{
+	struct node *node, *node1, *node2;
+	fuse_ino_t id1, id2;
+
+	node1 = lookup_node(f, nodeid1, name1);
+	id1 = node1 ? node1->nodeid : nodeid1;
+
+	node2 = lookup_node(f, nodeid2, name2);
+	id2 = node2 ? node2->nodeid : nodeid2;
+
+	for (node = get_node(f, id2); node->nodeid != FUSE_ROOT_ID;
+	     node = node->parent) {
+		if (node->name == NULL || node->parent == NULL)
+			break;
+
+		if (node->nodeid != id2 && node->nodeid == id1)
+			return -EINVAL;
+	}
+
+	if (node2)
+	{
+		for (node = get_node(f, id1); node->nodeid != FUSE_ROOT_ID;
+		     node = node->parent) {
+			if (node->name == NULL || node->parent == NULL)
+				break;
+
+			if (node->nodeid != id1 && node->nodeid == id2)
+				return -ENOTEMPTY;
+		}
+	}
+
+	return 0;
+}
+#endif
+
 static int try_get_path2(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
 			 fuse_ino_t nodeid2, const char *name2,
 			 char **path1, char **path2,
@@ -1245,6 +1288,17 @@ static int get_path2(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
 	int err;
 
 	pthread_mutex_lock(&f->lock);
+
+#if defined(CHECK_DIR_LOOP)
+	if (name1)
+	{
+		// called during rename; perform dir loop check
+		err = check_dir_loop(f, nodeid1, name1, nodeid2, name2);
+		if (err)
+			goto out_unlock;
+	}
+#endif
+
 	err = try_get_path2(f, nodeid1, name1, nodeid2, name2,
 			    path1, path2, wnode1, wnode2);
 	if (err == -EAGAIN) {
@@ -1265,6 +1319,10 @@ static int get_path2(struct fuse *f, fuse_ino_t nodeid1, const char *name1,
 		debug_path(f, "DEQUEUE PATH1", nodeid1, name1, !!wnode1);
 		debug_path(f, "        PATH2", nodeid2, name2, !!wnode2);
 	}
+
+#if defined(CHECK_DIR_LOOP)
+out_unlock:
+#endif
 	pthread_mutex_unlock(&f->lock);
 
 	return err;


### PR DESCRIPTION
This PR resolves the issue discussed in osxfuse/osxfuse#495. 

This PR fixes a rename hang when renaming directory loops. The hang can be easily demonstrated: start `fusexmp_fh` and issue the following shell command inside the mounted file system:

```console
$ mkdir -p a/b/c
$ mv a a/b/c
```

Some OS'es (such as Linux) perform the dir loop check (`rename("a", "a/b/c")` or `rename("a/b/c", "a")`, etc.) in the kernel. Unfortunately this is not the case with recent versions of macOS. This results in a hang in `get_path2`, because the original libfuse did not expect to handle such cases. How this happens is explained [here](https://github.com/libfuse/libfuse/issues/245#issuecomment-387845131).

The PR resolves the issue by adding a directory loop check in user mode. It has been tested against OSXFUSE using the small program included at the end of this post.

I submitted essentially the same patch to the original libfuse, because it solves the same problem in FreeBSD and it was recently accepted: libfuse/libfuse#250

Finally here is the small program I used to test:

```C
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <sys/stat.h>
#include <unistd.h>

void prename(const char *oldpath, const char *newpath, int expect_err)
{
    int err;

    err = -1 == rename(oldpath, newpath) ? errno : 0;
    if (err != expect_err)
        printf("rename(\"%s\", \"%s\") = %d (expect %d)\n", oldpath, newpath, err, expect_err);
    else
        printf("rename(\"%s\", \"%s\") = %d\n", oldpath, newpath, err);
}

int main()
{
    mkdir("a", 0700);
    prename("a", "a", 0);
    prename("a", "a/b", EINVAL);

    mkdir("a/b", 0700);
    mkdir("a/b/c", 0700);
    prename("a", "a/b/c", EINVAL);
    prename("a", "a/b/c/a", EINVAL);
    prename("a/b/c", "a", ENOTEMPTY);

    close(open("a/foo", O_CREAT));
    prename("a/foo", "a/bar", 0);
    prename("a/bar", "a/foo", 0);
    prename("a/foo", "a/b/bar", 0);
    prename("a/b/bar", "a/foo", 0);
    prename("a/foo", "a/b/c/bar", 0);
    prename("a/b/c/bar", "a/foo", 0);

    close(open("a/bar", O_CREAT));
    prename("a/foo", "a/bar", 0);
    unlink("a/bar");

    prename("a/b", "a/d", 0);
    prename("a/d", "a/b", 0);

    mkdir("a/d", 0700);
    prename("a/b", "a/d", 0);
    prename("a/d", "a/b", 0);

    mkdir("a/d", 0700);
    mkdir("a/d/e", 0700);
    prename("a/b", "a/d", ENOTEMPTY);
    rmdir("a/d/e");
    rmdir("a/d");

    rmdir("a/b/c");
    rmdir("a/b");
    rmdir("a");

    return 0;
}
```