### PR TITLE
Use _DARWIN_FEATURE_64_BIT_INODE instead of _DARWIN_USE_64_BIT_INODE

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -85,7 +85,7 @@ static void convert_stat(const struct stat *stbuf, struct fuse_attr *attr)
 	attr->ctimensec = ST_CTIM_NSEC(stbuf);
 #ifdef __APPLE__
 	attr->flags	= stbuf->st_flags;
-#ifdef _DARWIN_USE_64_BIT_INODE
+#ifdef _DARWIN_FEATURE_64_BIT_INODE
 	attr->crtime	= stbuf->st_birthtime;
 	attr->crtimensec= (uint32_t)(stbuf->st_birthtimensec);
 #else


### PR DESCRIPTION
_DARWIN_USE_64_BIT_INODE should not be used for checking as it might not be defined
even though 64-bit inode support is enabled (i.e. by default on 10.5+).
See stat(2) man page for details.