### PR TITLE
Join to mount callback thread on unmount

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -14,6 +14,7 @@
 #include "fuse_lowlevel.h"
 
 #ifdef __APPLE__
+#  include <pthread.h>
 #  include <DiskArbitration/DiskArbitration.h>
 #endif
 
@@ -119,6 +120,8 @@ int fuse_chan_clearfd(struct fuse_chan *ch);
 
 #ifdef __APPLE__
 void fuse_chan_set_disk(struct fuse_chan *ch, DADiskRef disk);
+void fuse_chan_set_mount_auxiliary_thread(struct fuse_chan* ch, pthread_t thread);
+void fuse_chan_join_mount_auxiliary_thread(struct fuse_chan* ch);
 void fuse_kern_unmount(DADiskRef disk, int fd);
 #else
 void fuse_kern_unmount(const char *mountpoint, int fd);
@@ -127,7 +130,7 @@ void fuse_kern_unmount(const char *mountpoint, int fd);
 #ifdef __APPLE__
 int fuse_kern_mount(const char *mountpoint, struct fuse_args *args,
 		    void (*callback)(void *, int),
-		    void *context);
+		    void *context, pthread_t* callback_thread_id);
 #else
 int fuse_kern_mount(const char *mountpoint, struct fuse_args *args);
 #endif

--- a/lib/fuse_session.c
+++ b/lib/fuse_session.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #ifdef __APPLE__
 #  include <sys/param.h>
+#  include <pthread.h>
 #endif
 
 #ifdef __APPLE__
@@ -38,6 +39,7 @@ struct fuse_chan {
 
 #ifdef __APPLE__
 	DADiskRef disk;
+	pthread_t mount_auxiliary_thread;
 #endif
 
 	size_t bufsize;
@@ -212,6 +214,23 @@ void fuse_chan_set_disk(struct fuse_chan *ch, DADiskRef disk)
 void fuse_chan_cleardisk(struct fuse_chan *ch)
 {
 	fuse_chan_set_disk(ch, NULL);
+}
+
+void fuse_chan_set_mount_auxiliary_thread(struct fuse_chan* ch, pthread_t thread)
+{
+    ch->mount_auxiliary_thread = thread;
+}
+
+void fuse_chan_join_mount_auxiliary_thread(struct fuse_chan* ch)
+{
+    pthread_t thread;
+
+    if (ch->mount_auxiliary_thread)
+    {
+        thread = ch->mount_auxiliary_thread;
+        ch->mount_auxiliary_thread = 0;
+        pthread_join(thread, NULL);
+    }
 }
 
 #endif /* __APPLE__ */


### PR DESCRIPTION
Mount callback thread launched in fuse_mount_core is not joined by anyone.
So it can be alive after FUSE deinitialization and it can cause crashes.
Wait it on unmount to fix the problem.